### PR TITLE
Improve magnet link regex

### DIFF
--- a/src/components/AddTorrentModal.jsx
+++ b/src/components/AddTorrentModal.jsx
@@ -13,7 +13,7 @@ function AddTorrentModal({ close, update }) {
     const insideDialogRef = useRef();
 
     // g means to get all occurences of pattern, i means case-insensitive
-    const magnetRegex = /magnet/gi;
+    const magnetRegex = /magnet:\?xt=urn:btih:/gi;
 
     useEffect(() => {
         function addTorrentHandler(e) {


### PR DESCRIPTION
If user were to add magnet link that contains word "magnet" in it, regex would trigger twice. This fixes it by detecting full magnet prefix in magnet link (before torrent hash and trackers), which hopefully exists only once in magnet link.